### PR TITLE
Fix: release bot token var

### DIFF
--- a/.github/workflows/semanticore.yml
+++ b/.github/workflows/semanticore.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Semanticore
         run: go run github.com/aoepeople/semanticore@v0
         env:
-          SEMANTICORE_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          SEMANTICORE_TOKEN: ${{secrets.PAT}}
           GIT_AUTHOR_NAME: 'Harjit Brar'
           GIT_AUTHOR_EMAIL: 'workandresearchbrar@gmail.com'
           GIT_COMMITTER_NAME: 'Harjit Brar'


### PR DESCRIPTION
### Issues
- github actions for automating release tags is having issue with authorization

### Fix Made
- created a personal access token and added it in the repository setting as `PAT`
- changed the secret token var used in the manifest file to `PAT`

### Merge Request Checklists
- [ ] I have already updated the sub-task ticket.
- [ ] I have already logged in the sub-task ticket.
- [ ] I have already covered the unit testing.
