### PR TITLE
Release v0.1.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,39 @@
+# Changelog
+
+## Version v0.1.0 (2024-06-17)
+
+### Features
+
+- added a release bot for main branch (70c050c1)
+- added sample test class (2cf3003e)
+- integrated JPA for player entity (e9c99d07)
+- added MainClass to run Spring (f5aabbce)
+- added gradle for this project (d4406574)
+- added resource properties for this project (fb624435)
+- added more stuff in gitignore (902d30e6)
+- fixing bash_history (ca45b202)
+- added gitignore (6a880916)
+- added docker compose for local (54538497)
+- added docker file for local spring (4c6577fd)
+- added gitattribute for LF changes (b03e237c)
+- added devcontainer.json (07fe6148)
+- added local docker compose manifest file (c25b639b)
+- added docker image manifest files for spring and mysql (1f0ed7b4)
+- added env for the docker image (50bd0979)
+- added bash feature in .devcontainer (dbe287a6)
+
+### Fixes
+
+- changed the token used by release bot to PAT var (d022cae0)
+- corrected a typo command in release bot manifest file (1f9f7f48)
+
+### Chores and tidying
+
+- renamed the pull request templates dir (7b5ce247)
+- added merge request templates (d973cfab)
+- caching bash commands i made (218ef6f0)
+
+### Other
+
+- Initial commit (19899db2)
+


### PR DESCRIPTION
# Release v0.1.0 🏆

## Summary

There are 17 🆕 feature, 2 👾 fix, 3 🧹 chore, 1 📝 other commits since v0.0.0.

This is a minor 📦 release.

Merge this pull request to commit the changelog and have Semanticore create a new release on the next pipeline run.

# Changelog

## Version v0.1.0 (2024-06-17)

### Features

- added a release bot for main branch (70c050c1)
- added sample test class (2cf3003e)
- integrated JPA for player entity (e9c99d07)
- added MainClass to run Spring (f5aabbce)
- added gradle for this project (d4406574)
- added resource properties for this project (fb624435)
- added more stuff in gitignore (902d30e6)
- fixing bash_history (ca45b202)
- added gitignore (6a880916)
- added docker compose for local (54538497)
- added docker file for local spring (4c6577fd)
- added gitattribute for LF changes (b03e237c)
- added devcontainer.json (07fe6148)
- added local docker compose manifest file (c25b639b)
- added docker image manifest files for spring and mysql (1f0ed7b4)
- added env for the docker image (50bd0979)
- added bash feature in .devcontainer (dbe287a6)

### Fixes

- changed the token used by release bot to PAT var (d022cae0)
- corrected a typo command in release bot manifest file (1f9f7f48)

### Chores and tidying

- renamed the pull request templates dir (7b5ce247)
- added merge request templates (d973cfab)
- caching bash commands i made (218ef6f0)

### Other

- Initial commit (19899db2)

---

This changelog was generated by your friendly [Semanticore Release Bot](https://github.com/aoepeople/semanticore)
