### PR TITLE
Release v0.6.2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version v0.6.2 (2025-01-15)
+
+### Chores and tidying
+
+- keeping main up to date (47b4a14a)
+
 ## Version v0.6.1 (2024-07-13)
 
 ### Refactoring


### PR DESCRIPTION
# Release v0.6.2 🏆

## Summary

There are 1 🧹 chore commits since v0.6.1.

This is a patch 🩹 release.

Merge this pull request to commit the changelog and have Semanticore create a new release on the next pipeline run.

# Changelog

## Version v0.6.2 (2025-01-15)

### Chores and tidying

- keeping main up to date (47b4a14a)

---

This changelog was generated by your friendly [Semanticore Release Bot](https://github.com/aoepeople/semanticore)
